### PR TITLE
Config logger + runtime option/flag config 

### DIFF
--- a/docs/changelogs/0.2.0.md
+++ b/docs/changelogs/0.2.0.md
@@ -20,6 +20,7 @@
 -|-|-
 [1](https://github.com/deeplime-io/onecode/issues/1) | New input element `FolderInput` | `FolderInput` allows folder selection. `LASConverter` example showcases it.
 [2](https://github.com/deeplime-io/onecode/issues/2) | New output element `PlotlyOutput` | `PlotlyOutput` allows to visualize Plotly charts. `ExperimentalVariography` example showcases it.
+[No ref] | Setup Project configuration through environment variables | Allow additional way to setup Project configuration options from command line.
 
 
 ## :warning: Breaking changes

--- a/docs/changelogs/0.2.0.md
+++ b/docs/changelogs/0.2.0.md
@@ -12,6 +12,7 @@
 [5](https://github.com/deeplime-io/onecode/issues/5) | Improving DeepLearning example | Allow initialization of `NeuralNetInput` custom element with different layer specs.
 [10](https://github.com/deeplime-io/onecode/issues/10) | Allow for custom import and init statements in InputElement and OutputElement | Streamlit `app.py` generated through `onecode-start` now has placeholders for import and init statements. See `imports()` and `init()` static methods in `InputElement` and `OutputElement`.
 [No ref] | Allow meta-data for elements | Meta-data can now be attached to any Input/Output element through `**kwargs`.
+[No Ref] | Namespace logging | Logger (info, warning, critical and debug) now uses a namespace `|OneCode|` rather than the root logging.
 
 
 ## New Features

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ of the OneCode Project (e.g. `cd /path/to/onecode/project`), then run it:
             is located under another folder.
     * Run a specific flow instead of the whole project: `python main.py --flow <flow_id>`
     * Get the full instructions set: `python main.py --help`
+    * Set a OneCode configuration option or flag at runtime by prepending `ONECODE_CONFIG_` or `ONECODE_FLAG_`: `ONECODE_FLAG_LOGGER_COLOR=1 python main.py` will set automatically `Project().set_config(ConfigOption.LOGGER_COLOR, True)`
 
 
 ---

--- a/onecode/base/enums.py
+++ b/onecode/base/enums.py
@@ -25,10 +25,15 @@ class ConfigOption(str, Enum):
     """
     Available options to control the configuration of the project.
 
-    - `FLUSH_STDOUT`: to force flushing the logger :octicons-arrow-both-24: `"FLUSH_STDOUT"`
+    - `FLUSH_STDOUT`: to force flushing the logger :octicons-arrow-both-24: `"FLUSH_STDOUT": False`
+    - `LOGGER_COLOR`: to color the logs by default when resetting the logger
+        :octicons-arrow-both-24: `"LOGGER_COLOR": True`
+    - `LOGGER_TIMESTAMP`: to timestamp the logs :octicons-arrow-both-24: `"LOGGER_TIMESTAMP": True`
 
     """
-    FLUSH_STDOUT        = "FLUSH_STDOUT"        # noqa: E-221
+    FLUSH_STDOUT        = "FLUSH_STDOUT"            # noqa: E-221
+    LOGGER_COLOR        = "LOGGER_COLOR"            # noqa: E-221
+    LOGGER_TIMESTAMP    = "LOGGER_TIMESTAMP"        # noqa: E-221
 
 
 class Mode(str, Enum):

--- a/onecode/base/enums.py
+++ b/onecode/base/enums.py
@@ -14,11 +14,14 @@ class Env(str, Enum):
     :octicons-arrow-both-24: `".onecode.json"`
     - `ONECODE_DO_TYPECHECK`: set to 1 to force runtime type-checking with Pydantic
     :octicons-arrow-both-24: `"ONECODE_DO_TYPECHECK"`
+    - `ONECODE_LOGGER_NAME`: base logger name to avoid logging conflict with other loggers
+    :octicons-arrow-both-24: `|OneCode|`
 
     """
     ONECODE_PROJECT_DATA    = "ONECODE_PROJECT_DATA"    # noqa: E-221
     ONECODE_CONFIG_FILE     = ".onecode.json"           # noqa: E-221
     ONECODE_DO_TYPECHECK    = "ONECODE_DO_TYPECHECK"    # noqa: E-221
+    ONECODE_LOGGER_NAME     = "|OneCode|"               # noqa: E-221
 
 
 class ConfigOption(str, Enum):

--- a/onecode/base/logger.py
+++ b/onecode/base/logger.py
@@ -8,7 +8,7 @@ import sys
 from typing import Optional
 
 from .decorator import check_type
-from .enums import ConfigOption
+from .enums import ConfigOption, Env
 from .project import Project
 from .singleton import Singleton
 
@@ -108,28 +108,29 @@ class Logger(metaclass=Singleton):
     """
 
     def __init__(self):
-        self.set_level(logging.INFO)
         self.reset()
 
     def reset(self) -> None:
         """
-        Remove all added handlers attached to the logger (see `logging.removeHandler()` for more
-        info) and reset to the default console stream handler with the
-        [ColoredFormatter][onecode.ColoredFormatter].
+        Remove all added handlers attached to the OneCode logger (see `logging.removeHandler()`
+        for more info) and reset to the default console stream handler with the
+        [ColoredFormatter][onecode.ColoredFormatter] with `INFO` level.
 
         """
-        logger = logging.getLogger()
-        while logger.hasHandlers():
+        logger = logging.getLogger(Env.ONECODE_LOGGER_NAME)
+        while len(logger.handlers) > 0:
             logger.removeHandler(logger.handlers[0])
 
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(ColoredFormatter(Project().get_config(ConfigOption.LOGGER_COLOR)))
-        logging.getLogger().addHandler(handler)
+        logging.getLogger(Env.ONECODE_LOGGER_NAME).addHandler(handler)
+        self.set_level(logging.INFO)
 
     @check_type
     def add_handler(
         self,
-        handler: Optional[logging.Handler] = None
+        handler: Optional[logging.Handler] = None,
+        root_logger: bool = True
     ) -> None:
         """
         Add an extra handler in addition to the default console stream one.
@@ -137,7 +138,8 @@ class Logger(metaclass=Singleton):
 
         Args:
             handler: New handler to add.
-
+            root_logger: If True, add the handler at the root logging, otherwise
+                as a child of the `|OneCode|` logger.
 
         !!! example
             ```py
@@ -153,7 +155,8 @@ class Logger(metaclass=Singleton):
 
         """
         if handler is not None:
-            logging.getLogger().addHandler(handler)
+            namespace = Env.ONECODE_LOGGER_NAME if not root_logger else None
+            logging.getLogger(namespace).addHandler(handler)
 
     @check_type
     def set_level(
@@ -161,7 +164,7 @@ class Logger(metaclass=Singleton):
         level: int
     ) -> None:
         """
-        Set the logger level. Default logging is INFO.
+        Set the OneCode logger level. Default logging is INFO.
 
         Args:
             level: Numerical value to set the logging level to. See
@@ -169,7 +172,7 @@ class Logger(metaclass=Singleton):
                 more information.
 
         """
-        logging.getLogger().setLevel(level)
+        logging.getLogger(Env.ONECODE_LOGGER_NAME).setLevel(level)
 
     @check_type
     def logger(
@@ -192,7 +195,7 @@ class Logger(metaclass=Singleton):
         """
         stack = inspect.stack()
         file = os.path.basename(stack[stacklevel].filename) if len(stack) > stacklevel else None
-        return logging.getLogger(file)
+        return logging.getLogger(f'{Env.ONECODE_LOGGER_NAME}.{file}')
 
     @staticmethod
     def _flush() -> None:

--- a/onecode/base/logger.py
+++ b/onecode/base/logger.py
@@ -62,7 +62,9 @@ class ColoredFormatter(logging.Formatter):
 
         """
         flow = Project().current_flow if Project().current_flow is not None else ''
-        format = f"%(asctime)s [%(levelname)s] {flow} - %(name)s:%(lineno)d - %(message)s"
+        format = f"[%(levelname)s] {flow} - %(name)s:%(lineno)d - %(message)s"
+        if Project().get_config(ConfigOption.LOGGER_TIMESTAMP):
+            format = f"%(asctime)s {format}"
 
         formats = {
             logging.DEBUG: f"{self.GREY}{format}{self.RESET}",
@@ -121,7 +123,7 @@ class Logger(metaclass=Singleton):
             logger.removeHandler(logger.handlers[0])
 
         handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(ColoredFormatter())
+        handler.setFormatter(ColoredFormatter(Project().get_config(ConfigOption.LOGGER_COLOR)))
         logging.getLogger().addHandler(handler)
 
     @check_type

--- a/onecode/base/project.py
+++ b/onecode/base/project.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023 DeepLime <contact@deeplime.io>
 # SPDX-License-Identifier: MIT
 
+import ast
 import json
 import os
 import sys
@@ -72,8 +73,17 @@ class Project(metaclass=Singleton):
         self._mode = Mode.CONSOLE
         self._flow = None
         self._data = None
+
+        # get string config from env variables starting with ONECODE_CONFIG_
+        # get flag config from env variables starting with ONECODE_FLAG_
         self._config = {
-            ConfigOption.FLUSH_STDOUT: False
+            ConfigOption.FLUSH_STDOUT: False,
+            ConfigOption.LOGGER_COLOR: True,
+            ConfigOption.LOGGER_TIMESTAMP: True,
+            **{k[len("ONECODE_CONFIG_"):]: os.environ[k]
+                for k in os.environ if k.startswith("ONECODE_CONFIG_")},
+            **{k[len("ONECODE_FLAG_"):]: bool(ast.literal_eval(os.environ[k]))
+                for k in os.environ if k.startswith("ONECODE_FLAG_")},
         }
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ streamlit = { version = ">=1.12.0,<1.18", optional = true }
 streamlit-image-select = { version = "^0.5.1", optional = true }
 streamlit-option-menu = { version = "^0.3.2", optional = true }
 streamlit_tree_select = { version = "^0.0.5", optional = true }
+altair = { version = "<5", optional = true }
 
 # docs
 griffe = { version = "==0.25.0", optional = true }
@@ -63,6 +64,7 @@ toml = { version = "^0.10.2", optional = true }
 
 [tool.poetry.extras]
 tech-expert = [
+    "altair",
     "streamlit",
     "streamlit-image-select",
     "streamlit-option-menu",
@@ -70,6 +72,7 @@ tech-expert = [
 ]
 
 developer = [
+    "altair",
     "streamlit",
     "streamlit-image-select",
     "streamlit-option-menu",

--- a/tests/unit/base/test_logger.py
+++ b/tests/unit/base/test_logger.py
@@ -1,6 +1,6 @@
 import logging
 
-from onecode import ColoredFormatter, ConfigOption, Logger, Project
+from onecode import ColoredFormatter, ConfigOption, Env, Logger, Project
 
 
 def test_logger_debug(caplog):
@@ -15,33 +15,43 @@ def test_logger_debug(caplog):
 def test_logger_info(caplog):
     with caplog.at_level(logging.INFO):
         Logger.info("This is an info")
+        Logger.warning("This is a warning")
 
     assert logging.INFO == caplog.record_tuples[0][1]
     assert "This is an info" == caplog.record_tuples[0][2]
+
+    assert logging.WARNING == caplog.record_tuples[1][1]
+    assert "This is a warning" == caplog.record_tuples[1][2]
 
 
 def test_logger_warning(caplog):
     with caplog.at_level(logging.WARNING):
         Logger.warning("This is a warning")
+        Logger.info("This is an info")
 
     assert logging.WARNING == caplog.record_tuples[0][1]
     assert "This is a warning" == caplog.record_tuples[0][2]
+    assert len(caplog.record_tuples) == 1
 
 
 def test_logger_error(caplog):
     with caplog.at_level(logging.ERROR):
         Logger.error("This is an error")
+        Logger.warning("This is a warning")
 
     assert logging.ERROR == caplog.record_tuples[0][1]
     assert "This is an error" == caplog.record_tuples[0][2]
+    assert len(caplog.record_tuples) == 1
 
 
 def test_logger_critical(caplog):
     with caplog.at_level(logging.CRITICAL):
         Logger.critical("This is a critical error")
+        Logger.error("This is an error")
 
     assert logging.CRITICAL == caplog.record_tuples[0][1]
     assert "This is a critical error" == caplog.record_tuples[0][2]
+    assert len(caplog.record_tuples) == 1
 
 
 def test_logger_level(caplog):
@@ -80,7 +90,8 @@ def test_invalid_handler():
     Logger().add_handler(handler)
     Logger.info("Hello from OneCode!")
 
-    assert handler.log.split(' - ')[1] == str("test_logger.py:81")
+    assert handler.log.split(' - ')[1] == \
+        str(f"{Env.ONECODE_LOGGER_NAME}.test_logger.py:91")
     assert handler.log.split(' - ')[2] == str("Hello from OneCode!")
 
 

--- a/tests/unit/base/test_project.py
+++ b/tests/unit/base/test_project.py
@@ -32,7 +32,9 @@ def test_empty_project():
     assert p.current_flow is None
     assert p.data is None
     assert p.config == {
-        ConfigOption.FLUSH_STDOUT: False
+        ConfigOption.FLUSH_STDOUT: False,
+        ConfigOption.LOGGER_COLOR: True,
+        ConfigOption.LOGGER_TIMESTAMP: True,
     }
     assert p.data_root == os.getcwd()
     assert p.get_input_path('test.txt') == os.path.join(os.getcwd(), 'test.txt')
@@ -74,7 +76,9 @@ def test_project_reset():
     assert p.current_flow == 'testflow'
     assert p.data == {"x": 4}
     assert p.config == {
-        ConfigOption.FLUSH_STDOUT: True
+        ConfigOption.FLUSH_STDOUT: True,
+        ConfigOption.LOGGER_COLOR: True,
+        ConfigOption.LOGGER_TIMESTAMP: True,
     }
     assert p.data_root == data_path
     assert p.get_input_path('test.txt') == os.path.join(data_path, 'test.txt')
@@ -104,7 +108,9 @@ def test_project_reset():
     assert p.current_flow is None
     assert p.data is None
     assert p.config == {
-        ConfigOption.FLUSH_STDOUT: False
+        ConfigOption.FLUSH_STDOUT: False,
+        ConfigOption.LOGGER_COLOR: True,
+        ConfigOption.LOGGER_TIMESTAMP: True
     }
     assert p.data_root == os.getcwd()
     assert p.get_input_path('test.txt') == os.path.join(os.getcwd(), 'test.txt')
@@ -214,6 +220,8 @@ def test_config_option():
     assert p.get_config('XX') == 56.4
     assert p.config == {
         ConfigOption.FLUSH_STDOUT: False,
+        ConfigOption.LOGGER_COLOR: True,
+        ConfigOption.LOGGER_TIMESTAMP: True,
         'XX': 56.4
     }
 


### PR DESCRIPTION
* Improve Logger class by namespacing it with `|OneCode|` rather than using the root logger.
* Allow to set config options/flag at runtime through env variables