### PR TITLE
adding flag CLOUD_ENV to be used by OneCode Cloud

### DIFF
--- a/docs/changelogs/1.2.0.md
+++ b/docs/changelogs/1.2.0.md
@@ -8,6 +8,7 @@
 
 :octicons-issue-opened-24: Issue Ref | :fontawesome-solid-thumbtack: Summary | :material-message-text: Description
 -|-|-
+[No ref] | Adding flag to detect OneCode Cloud env | Useful flag to handle local vs cloud env when running code using display (e.g. plot show).
 
 
 ## New Features

--- a/onecode/base/enums.py
+++ b/onecode/base/enums.py
@@ -35,12 +35,15 @@ class ConfigOption(StrEnum):
     - `LOGGER_TIMESTAMP`: to timestamp the logs :octicons-arrow-both-24: `"LOGGER_TIMESTAMP": True`
     - `CHECK_MODULES`: to check modules in requirements.txt are present in the current environment
         when starting the OneCode application :octicons-arrow-both-24: `"CHECK_MODULES": True`
+    - `CLOUD_ENV`: used by OneCode Cloud to identify cloud env
+        typically to handle code using display :octicons-arrow-both-24: `"CLOUD_ENV": False`
 
     """
     FLUSH_STDOUT        = "FLUSH_STDOUT"            # noqa: E-221
     LOGGER_COLOR        = "LOGGER_COLOR"            # noqa: E-221
     LOGGER_TIMESTAMP    = "LOGGER_TIMESTAMP"        # noqa: E-221
     CHECK_MODULES       = "CHECK_MODULES"           # noqa: E-221
+    CLOUD_ENV           = "CLOUD_ENV"               # noqa: E-221
 
 
 class Mode(StrEnum):

--- a/onecode/base/project.py
+++ b/onecode/base/project.py
@@ -89,6 +89,7 @@ class Project(metaclass=Singleton):
             ConfigOption.LOGGER_COLOR: True,
             ConfigOption.LOGGER_TIMESTAMP: True,
             ConfigOption.CHECK_MODULES: True,
+            ConfigOption.CLOUD_ENV: False,
             **{k[len("ONECODE_CONFIG_"):]: os.environ[k]
                 for k in os.environ if k.startswith("ONECODE_CONFIG_")},
             **{k[len("ONECODE_FLAG_"):]: bool(ast.literal_eval(os.environ[k]))

--- a/tests/unit/base/test_project.py
+++ b/tests/unit/base/test_project.py
@@ -32,6 +32,7 @@ def test_empty_project():
         ConfigOption.LOGGER_COLOR: True,
         ConfigOption.LOGGER_TIMESTAMP: True,
         ConfigOption.CHECK_MODULES: True,
+        ConfigOption.CLOUD_ENV: False,
     }
     assert p.data_root == os.getcwd()
     assert p.get_input_path('test.txt') == os.path.join(os.getcwd(), 'test.txt')
@@ -73,6 +74,7 @@ def test_project_reset():
         ConfigOption.LOGGER_COLOR: True,
         ConfigOption.LOGGER_TIMESTAMP: True,
         ConfigOption.CHECK_MODULES: True,
+        ConfigOption.CLOUD_ENV: False,
     }
     assert p.data_root == data_path
     assert p.get_input_path('test.txt') == os.path.join(data_path, 'test.txt')
@@ -101,6 +103,7 @@ def test_project_reset():
         ConfigOption.LOGGER_COLOR: True,
         ConfigOption.LOGGER_TIMESTAMP: True,
         ConfigOption.CHECK_MODULES: True,
+        ConfigOption.CLOUD_ENV: False,
     }
     assert p.data_root == os.getcwd()
     assert p.get_input_path('test.txt') == os.path.join(os.getcwd(), 'test.txt')
@@ -213,6 +216,7 @@ def test_config_option():
         ConfigOption.LOGGER_COLOR: True,
         ConfigOption.LOGGER_TIMESTAMP: True,
         ConfigOption.CHECK_MODULES: True,
+        ConfigOption.CLOUD_ENV: False,
         'XX': 56.4
     }
 


### PR DESCRIPTION
This is a helper flag for devs to identify in their code when the app is running in OneCode Cloud rather than locally.
This could be useful for instance with plot `show()` popping up locally but not in the cloud (saving figures as files instead).