### PR TITLE
Python 3.13 support

### DIFF
--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install Python libraries
       run: |

--- a/.github/workflows/documentation_builder.yml
+++ b/.github/workflows/documentation_builder.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Python libraries
         run: |

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install Formatting
         run: |
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: ["3.10"]
+        python: ["3.11"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:

--- a/docs/changelogs/1.2.0.md
+++ b/docs/changelogs/1.2.0.md
@@ -8,7 +8,7 @@
 
 :octicons-issue-opened-24: Issue Ref | :fontawesome-solid-thumbtack: Summary | :material-message-text: Description
 -|-|-
-
+[No Ref] | Python version 3.13 now supported | All Python versions ranging from 3.10 through 3.13 are now supported.
 
 ## New Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.13"
+python = ">=3.8, <3.14"
 'flufl.lock' = ">=7.1.1,<9"
 pandas = ">=1.4.0,<3"
 pydash = ">=5.1.0,<8"

--- a/tests/unit/base/test_project.py
+++ b/tests/unit/base/test_project.py
@@ -11,7 +11,10 @@ from tests.utils.flow_cli import _clean_flow, _generate_flow_name
 
 def test_empty_project():
     p = Project()
-    dr = 2 if os.name == 'nt' else 0    # typicall "D:"
+    dr = 2 if os.name == 'nt' else 0    # typically "D:" or "C:"
+
+    # python 3.13+ on Windows, os.path.isabs('/data/test.txt) now returns False
+    dr13 = 2 if os.name == 'nt' and sys.version_info >= (3, 13) else 0
 
     assert p.registered_elements == {
         'onecode.Checkbox',
@@ -35,14 +38,18 @@ def test_empty_project():
     }
     assert p.data_root == os.getcwd()
     assert p.get_input_path('test.txt') == os.path.join(os.getcwd(), 'test.txt')
-    assert p.get_input_path('/path/to/test.txt') == '/path/to/test.txt'
+    assert p.get_input_path('/path/to/test.txt')[dr13:] == '/path/to/test.txt'
     assert p.get_output_path('test.txt') == os.path.join(os.getcwd(), 'outputs', 'test.txt')
     assert p.get_output_path('/path/to/test.txt')[dr:] == '/path/to/test.txt'
 
 
 def test_project_reset():
     p = Project()
-    dr = 2 if os.name == 'nt' else 0    # typicall "D:"
+    dr = 2 if os.name == 'nt' else 0    # typically "D:" or "C:"
+
+    # python 3.13+ on Windows, os.path.isabs('/data/test.txt) now returns False
+    dr13 = 2 if os.name == 'nt' and sys.version_info >= (3, 13) else 0
+
     data_path = os.path.join(os.getcwd(), 'tests', 'data')
     os.environ[Env.ONECODE_PROJECT_DATA] = data_path
     p.reset()
@@ -76,7 +83,7 @@ def test_project_reset():
     }
     assert p.data_root == data_path
     assert p.get_input_path('test.txt') == os.path.join(data_path, 'test.txt')
-    assert p.get_input_path('/path/to/test.txt') == '/path/to/test.txt'
+    assert p.get_input_path('/path/to/test.txt')[dr13:] == '/path/to/test.txt'
     assert p.get_output_path('test.txt') == os.path.join(data_path, 'outputs', 'test.txt')
     assert p.get_output_path('/path/to/test.txt')[dr:] == '/path/to/test.txt'
 
@@ -104,7 +111,7 @@ def test_project_reset():
     }
     assert p.data_root == os.getcwd()
     assert p.get_input_path('test.txt') == os.path.join(os.getcwd(), 'test.txt')
-    assert p.get_input_path('/path/to/test.txt') == '/path/to/test.txt'
+    assert p.get_input_path('/path/to/test.txt')[dr13:] == '/path/to/test.txt'
     assert p.get_output_path('test.txt') == os.path.join(os.getcwd(), 'outputs', 'test.txt')
     assert p.get_output_path('/path/to/test.txt')[dr:] == '/path/to/test.txt'
 


### PR DESCRIPTION
## Note

Deprecation warnings in `onecode-pycg`  will be handled with release `onecode-pycg==1.2.0` (includes https://github.com/deeplime-io/PyCG/commit/e8e28278beb19ef7721891def82255c14d9436bc)

## Instruction

To be merged after #41 as it will conflict on the doc `1.2.0.md`