### PR TITLE
onecode zip avoid warnings on duplicate files

### DIFF
--- a/docs/changelogs/1.2.0.md
+++ b/docs/changelogs/1.2.0.md
@@ -12,6 +12,7 @@
 -|-|-
 [No ref] | Adding flag to detect OneCode Cloud env | Useful flag to handle local vs cloud env when running code using display (e.g. plot show).
 [No Ref] | Python version 3.13 now supported | All Python versions ranging from 3.10 through 3.13 are now supported.
+[No Ref] | No longer checking modules at startup | `ONECODE_FLAG_CHECK_MODULES` not set to False by default as verbosity is annoying, especially combined with #45.
 
 
 ## New Features

--- a/docs/changelogs/1.2.0.md
+++ b/docs/changelogs/1.2.0.md
@@ -13,6 +13,7 @@
 [No ref] | Adding flag to detect OneCode Cloud env | Useful flag to handle local vs cloud env when running code using display (e.g. plot show).
 [No Ref] | Python version 3.13 now supported | All Python versions ranging from 3.10 through 3.13 are now supported.
 [No Ref] | No longer checking modules at startup | `ONECODE_FLAG_CHECK_MODULES` not set to False by default as verbosity is annoying, especially combined with #45.
+[No Ref] | Avoid warnings on duplicate files with `onecode-zip` | `onecode-zip` checks first if file already added to the archive (in case of duplicates entry in MANIFEST).
 
 
 ## New Features

--- a/onecode/base/project.py
+++ b/onecode/base/project.py
@@ -88,7 +88,7 @@ class Project(metaclass=Singleton):
             ConfigOption.FLUSH_STDOUT: False,
             ConfigOption.LOGGER_COLOR: True,
             ConfigOption.LOGGER_TIMESTAMP: True,
-            ConfigOption.CHECK_MODULES: True,
+            ConfigOption.CHECK_MODULES: False,
             ConfigOption.CLOUD_ENV: False,
             **{k[len("ONECODE_CONFIG_"):]: os.environ[k]
                 for k in os.environ if k.startswith("ONECODE_CONFIG_")},

--- a/onecode/cli/zip.py
+++ b/onecode/cli/zip.py
@@ -31,6 +31,7 @@ def zip_output(
     """
 
     compression = zipfile.ZIP_STORED if compression_level == 0 else zipfile.ZIP_DEFLATED
+    files_in_archive = set()
     with zipfile.ZipFile(
         to_file,
         "w",
@@ -51,6 +52,11 @@ def zip_output(
                             "outputs",
                             os.path.relpath(output_file, os.path.join(data_path, "outputs"))
                         )
+
+                        if arcpath in files_in_archive:    # pragma: no cover
+                            continue
+
+                        files_in_archive.add(arcpath)
 
                         if verbose:
                             print(f"Archiving {output['key']}: {output_file} => {arcpath}")

--- a/tests/unit/base/test_project.py
+++ b/tests/unit/base/test_project.py
@@ -34,7 +34,7 @@ def test_empty_project():
         ConfigOption.FLUSH_STDOUT: False,
         ConfigOption.LOGGER_COLOR: True,
         ConfigOption.LOGGER_TIMESTAMP: True,
-        ConfigOption.CHECK_MODULES: True,
+        ConfigOption.CHECK_MODULES: False,
         ConfigOption.CLOUD_ENV: False,
     }
     assert p.data_root == os.getcwd()
@@ -80,7 +80,7 @@ def test_project_reset():
         ConfigOption.FLUSH_STDOUT: True,
         ConfigOption.LOGGER_COLOR: True,
         ConfigOption.LOGGER_TIMESTAMP: True,
-        ConfigOption.CHECK_MODULES: True,
+        ConfigOption.CHECK_MODULES: False,
         ConfigOption.CLOUD_ENV: False,
     }
     assert p.data_root == data_path
@@ -109,7 +109,7 @@ def test_project_reset():
         ConfigOption.FLUSH_STDOUT: False,
         ConfigOption.LOGGER_COLOR: True,
         ConfigOption.LOGGER_TIMESTAMP: True,
-        ConfigOption.CHECK_MODULES: True,
+        ConfigOption.CHECK_MODULES: False,
         ConfigOption.CLOUD_ENV: False,
     }
     assert p.data_root == os.getcwd()
@@ -222,7 +222,7 @@ def test_config_option():
         ConfigOption.FLUSH_STDOUT: False,
         ConfigOption.LOGGER_COLOR: True,
         ConfigOption.LOGGER_TIMESTAMP: True,
-        ConfigOption.CHECK_MODULES: True,
+        ConfigOption.CHECK_MODULES: False,
         ConfigOption.CLOUD_ENV: False,
         'XX': 56.4
     }


### PR DESCRIPTION
multiple `file_output` with the same path would trigger a warning on `onecode-zip` archiving.